### PR TITLE
Resolve dependencies with a custom AssemblyLoadContext

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/src/XMLDoc2Markdown/bin/Debug/net5.0/XMLDoc2Markdown.dll",
             "args": [
-                "${workspaceFolder}/sample/MyClassLib/bin/Release/netstandard2.0/MyClassLib.dll",
+                "${workspaceFolder}/sample/MyClassLib/bin/Debug/netstandard2.0/MyClassLib.dll",
                 "${workspaceFolder}/docs/sample",
                 "--examples-path",
                 "${workspaceFolder}/sample/docs/examples",

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -72,7 +72,9 @@ namespace XMLDoc2Markdown
                     Directory.CreateDirectory(@out);
                 }
 
-                var assembly = Assembly.LoadFrom(src);
+                Assembly assembly = new AssemblyLoadContext(src)
+                    .LoadFromAssemblyName(new AssemblyName(Path.GetFileNameWithoutExtension(src)));
+
                 string assemblyName = assembly.GetName().Name;
                 var documentation = new XmlDocumentation(src);
 

--- a/src/XMLDoc2Markdown/Properties/launchSettings.json
+++ b/src/XMLDoc2Markdown/Properties/launchSettings.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "profiles": {
     "XMLDoc2Markdown": {
-      "commandName": "Project",
-      "commandLineArgs": "../../../../../publish/MyClassLib.dll ../../../../../docs/sample --examples-path ../../../../../sample/docs/examples --github-pages"
+        "commandName": "Project",
+        "commandLineArgs": "../../../../../sample/MyClassLib/bin/Debug/netstandard2.0/MyClassLib.dll ../../../../../docs/sample --examples-path ../../../../../sample/docs/examples --github-pages --back-button"
     }
   }
 }

--- a/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
+++ b/src/XMLDoc2Markdown/Utils/AssemblyLoadContext.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace XMLDoc2Markdown.Utils
+{
+    internal class AssemblyLoadContext : System.Runtime.Loader.AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver resolver;
+
+        public AssemblyLoadContext(string pluginPath)
+        {
+            this.resolver = new AssemblyDependencyResolver(pluginPath);
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            string assemblyPath = this.resolver.ResolveAssemblyToPath(assemblyName);
+            if (assemblyPath != null)
+            {
+                return this.LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            string libraryPath = this.resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (libraryPath != null)
+            {
+                return this.LoadUnmanagedDllFromPath(libraryPath);
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}


### PR DESCRIPTION
Hi @charlesdevandiere!

First, thanks for this great and simple tool!
I wanted to use it, but encountered the following error with projects having NuGet dependencies:
```
22>Generation started: Assembly: Proffer.Email.SendGrid
23>  proffer.email.smtpemailservicecollectionextensions.md
22>Unable to generate documentation:
22>Unable to load one or more of the requested types.
22>Could not load file or assembly 'SendGrid, Version=9.23.1.0, Culture=neutral, PublicKeyToken=4f047e93159395ca'. The system cannot find the file specified.
22>D:\Repos\Github\asiffermann\proffer\src\Directory.Build.targets(4,5): error MSB3073: The command "dotnet xmldoc2md "D:\Repos\Github\asiffermann\proffer\src\Proffer.Email.SendGrid\bin\Debug\netstandard2\Proffer.Email.SendGrid.dll" docs\code --github-pages --back-button" exited with code 1.
```

So I followed [.NET Core documentation to safely load plugins with dependencies](https://docs.microsoft.com/en-us/dotnet/core/tutorials/creating-app-with-plugin-support), and added a custom `AssemblyLoadContext` to your project. With this addition, the tool generates markup as expected for all my libraries.

I also fixed the debug launch settings to work on both Visual Studio and VS Code with a simple debug build.
