### PR TITLE
fix: newlines in enum members and add XElement support.

### DIFF
--- a/docs/sample/myclasslib.myenum.md
+++ b/docs/sample/myclasslib.myenum.md
@@ -19,7 +19,7 @@ Implements [IComparable](https://docs.microsoft.com/en-us/dotnet/api/system.icom
 
 | Name | Value | Description |
 | --- | --: | --- |
-| Default | 0 | The default. |
+| Default | 0 | The default value for [MyEnum](./myclasslib.myenum). This is additional information. |
 | First | 1 | The first. |
 | Second | 2 | The second. |
 

--- a/sample/MyClassLib/MyEnum.cs
+++ b/sample/MyClassLib/MyEnum.cs
@@ -6,7 +6,8 @@ namespace MyClassLib
     public enum MyEnum
     {
         /// <summary>
-        /// The default.
+        /// The default value for <see cref="MyEnum"/>.
+        /// This is additional information.
         /// </summary>
         Default = 0,
 


### PR DESCRIPTION
Resolves #23 

- Remove newlines from enum summaries so the generated markdown table doesn't break
- Add proper XElement to markdown support for Enums


## Example
```C#
// ...
/// <summary>
/// The default value for <see cref="MyEnum"/>.
/// This is additional information.
/// </summary>
Default = 0,
```

### Before

| Name | Value | Description |
| --- | --: | --- |
| Default | 0 | The default value for .
            This is additional information. |
| First | 1 | The first. |
| Second | 2 | The second. |

### After
| Name | Value | Description |
| --- | --: | --- |
| Default | 0 | The default value for [MyEnum](./myclasslib.myenum). This is additional information. |
| First | 1 | The first. |
| Second | 2 | The second. |