### PR TITLE
Fix return and add rich xml support for all types

### DIFF
--- a/docs/sample/myclasslib.myclass.md
+++ b/docs/sample/myclasslib.myclass.md
@@ -42,7 +42,7 @@ public string MyProperty { get; protected set; }
 #### Property Value
 
 [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
-The property value.
+The property value. Used by [MyClass.DoGeneric&lt;T&gt;(T)](./myclasslib.myclass#dogenerictt).
 
 #### Example
 
@@ -125,6 +125,34 @@ The second param.
 
 [Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception)<br>
 Thrown when...
+
+### **DoGeneric&lt;T&gt;(T)**
+
+Do some thing.
+
+```csharp
+public int DoGeneric<T>(T value)
+```
+
+#### Type Parameters
+
+`T`<br>
+The type argument. Used by [MyClass.DoGeneric&lt;T&gt;(T)](./myclasslib.myclass#dogenerictt).
+
+#### Parameters
+
+`value` T<br>
+The param. Used by [MyClass.DoGeneric&lt;T&gt;(T)](./myclasslib.myclass#dogenerictt).
+
+#### Returns
+
+[Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32)<br>
+Returns a value [Int32](https://docs.microsoft.com/en-us/dotnet/api/system.int32).
+
+#### Exceptions
+
+[ArgumentException](https://docs.microsoft.com/en-us/dotnet/api/system.argumentexception)<br>
+Thrown instead of [Exception](https://docs.microsoft.com/en-us/dotnet/api/system.exception).
 
 ### **Get(List&lt;String&gt;)**
 

--- a/docs/sample/myclasslib.subnamespace.subclass.md
+++ b/docs/sample/myclasslib.subnamespace.subclass.md
@@ -38,7 +38,7 @@ public string MyProperty { get; protected set; }
 #### Property Value
 
 [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
-The property value.
+The property value. Used by [MyClass.DoGeneric&lt;T&gt;(T)](./myclasslib.myclass#dogenerictt).
 
 #### Example
 

--- a/sample/MyClassLib/MyClass.cs
+++ b/sample/MyClassLib/MyClass.cs
@@ -17,7 +17,7 @@ namespace MyClassLib
         /// <summary>
         /// My property.
         /// </summary>
-        /// <value>The property value.</value>
+        /// <value>The property value. Used by <see cref="DoGeneric{T}(T)"/>.</value>
         public string MyProperty { get; protected set; }
 
         /// <summary>
@@ -78,6 +78,15 @@ namespace MyClassLib
         /// <param name="secondParam">The second param.</param>
         /// <exception cref="System.Exception">Thrown when...</exception>
         public void Do(string firstParam, int secondParam) { }
+
+        /// <summary>
+        /// Do some thing.
+        /// </summary>
+        /// <typeparam name="T">The type argument. Used by <see cref="DoGeneric{T}(T)"/>.</typeparam>
+        /// <param name="value">The param. Used by <see cref="DoGeneric{T}(T)"/>.</param>
+        /// <returns>Returns a value <see cref="int"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown instead of <see cref="Exception"/>.</exception>
+        public int DoGeneric<T>(T value) { throw new ArgumentException(); }
 
         /// <summary>
         /// Gets some thing.

--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -82,7 +82,6 @@ class Program
 
             string assemblyName = assembly.GetName().Name;
             XmlDocumentation documentation = new(src);
-
             Logger.Info($"Generation started: Assembly: {assemblyName}");
 
             IMarkdownDocument indexPage = new MarkdownDocument().AppendHeader(assemblyName, 1);


### PR DESCRIPTION
Updated all writers to use `XNodesToMarkdownParagraph` where possible. This should resolve #24 and #17 and support all tags such as `see` for properties, exceptions, generic types, parameters, returns and enum states. 

Refactored `TryGetMemberInfoFromReference` to use specific generic types and support methods with no parameters.