### PR TITLE
Handle in, out and ref parameters in method signature

### DIFF
--- a/docs/sample/myclasslib.myclass.md
+++ b/docs/sample/myclasslib.myclass.md
@@ -248,6 +248,27 @@ This example call the `Get` method.
 var bar = foo.Get("bar");
 ```
 
+### **TryGet(Int64, String)**
+
+Try to get some thing.
+
+```csharp
+public bool TryGet(long param, out string result)
+```
+
+#### Parameters
+
+`param` [Int64](https://docs.microsoft.com/en-us/dotnet/api/system.int64)<br>
+The param.
+
+`result` [String](https://docs.microsoft.com/en-us/dotnet/api/system.string)<br>
+The output param.
+
+#### Returns
+
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)<br>
+true if the function succeeded false otherwise
+
 ### **StaticMethod()**
 
 A static method.

--- a/sample/MyClassLib/MyClass.cs
+++ b/sample/MyClassLib/MyClass.cs
@@ -102,6 +102,18 @@ public class MyClass : IMyInterface
     public string Get(List<string> param) => string.Empty;
 
     /// <summary>
+    /// Try to get some thing.
+    /// </summary>
+    /// <param name="param">The param.</param>
+    /// <param name="result">The output param.</param>
+    /// <returns> true if the function succeeded false otherwise</returns>
+    public bool TryGet(long param, out string result)
+    {
+        result = string.Empty;
+        return true;
+    }
+
+    /// <summary>
     /// A static method.
     /// </summary>
     public static void StaticMethod() { }

--- a/src/XMLDoc2Markdown/Properties/launchSettings.json
+++ b/src/XMLDoc2Markdown/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "XMLDoc2Markdown": {
       "commandName": "Project",
-      "commandLineArgs": "../../../../../sample/MyClassLib/bin/Debug/netstandard2.0/MyClassLib.dll ../../../../../docs/sample --examples-path ../../../../../sample/docs/examples --github-pages --back-button"
+      "commandLineArgs": "../../../../../sample/MyClassLib/bin/Debug/netstandard2.0/MyClassLib.dll -o ../../../../../docs/sample --examples-path ../../../../../sample/docs/examples --github-pages --back-button"
     }
   }
 }

--- a/src/XMLDoc2Markdown/TypeDocumentation.cs
+++ b/src/XMLDoc2Markdown/TypeDocumentation.cs
@@ -576,7 +576,7 @@ internal class TypeDocumentation
 
         foreach (ParameterInfo param in @params)
         {
-            MarkdownInlineElement typeName = param.ParameterType.GetDocsLink(
+            MarkdownInlineElement typeName = param.GetActualType().GetDocsLink(
                 this.assembly,
                 this.options.Structure,
                 noExtension: this.options.GitHubPages || this.options.GitlabWiki,

--- a/src/XMLDoc2Markdown/Utils/MethodBaseExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/MethodBaseExtensions.cs
@@ -76,10 +76,8 @@ internal static class MethodBaseExtensions
                 displayName += $"<{string.Join(", ", genericArguments.Select(a => a.Name))}>";
             }
         }
-        ParameterInfo[] @params = methodBase.GetParameters();
-        IEnumerable<string> paramsNames = @params
-            .Select(p => $"{p.ParameterType.GetDisplayName(simplifyName: full)}{(full ? $" {p.Name}" : null)}");
-        displayName += $"({string.Join(", ", paramsNames)})";
+
+        displayName += $"({string.Join(", ", methodBase.GetParameters().Select(p => p.GetDisplayLabel(full)))})";
         signature.Add(displayName);
 
         return string.Join(' ', signature);

--- a/src/XMLDoc2Markdown/Utils/ParameterInfoExtension.cs
+++ b/src/XMLDoc2Markdown/Utils/ParameterInfoExtension.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using System.Text;
+
+namespace XMLDoc2Markdown.Utils
+{
+    internal static class ParameterInfoExtension
+    {
+        public static Type GetActualType(this ParameterInfo parameter)
+            => parameter.ParameterType.IsByRef ? parameter.ParameterType.GetElementType()! : parameter.ParameterType;
+
+        public static string GetDisplayLabel(this ParameterInfo parameter, bool full = false)
+        {
+            StringBuilder nameBuilder = new();
+
+            if (full && parameter.ParameterType.IsByRef)
+            {
+                string prefix = parameter.IsIn ? "in "
+                              : parameter.IsOut ? "out "
+                              : "ref ";
+                nameBuilder.Append(prefix);
+            }
+
+            nameBuilder.Append(parameter.GetActualType().GetDisplayName(simplifyName: full));
+
+            if (full)
+                nameBuilder.Append($" {parameter.Name}");
+
+            return nameBuilder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Currently, in, out and ref parameters are not displayed correctly.
they appear like this:
```csharp
public static bool TryParse(string s, Int64& result)
```
instead of this:
```csharp
public static bool TryParse(string s, out long result)
```

This PR should fix that