### PR TITLE
Support for .net9 applications.

### DIFF
--- a/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
+++ b/src/XMLDoc2Markdown/XMLDoc2Markdown.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.0.0</Version>
     <AssemblyName>xmldoc2md</AssemblyName>


### PR DESCRIPTION
On .Net 9 applications you can't use the tool. It says: 

Could not load file or assembly 'System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.

After make the tool itself also support .net9, the issue is gone.