### PR TITLE
Improve Markdown rendering for cref references

### DIFF
--- a/src/XMLDoc2Markdown/TypeDocumentation.cs
+++ b/src/XMLDoc2Markdown/TypeDocumentation.cs
@@ -679,7 +679,13 @@ internal class TypeDocumentation
                 noPrefix: this.options.GitlabWiki);
         }
 
-        return new MarkdownText(text ?? crefAttribute);
+        if (!string.IsNullOrWhiteSpace(text))
+            return new MarkdownText(text);
+
+        if (!string.IsNullOrWhiteSpace(crefAttribute) && crefAttribute.Length > 2)
+            return new MarkdownInlineCode(crefAttribute[2..]);
+
+        return new MarkdownText(string.Empty);
     }
 
     private bool TryGetMemberInfoFromReference(string? crefAttribute, out MemberInfo? memberInfo)


### PR DESCRIPTION
Enhances handling of cref references by rendering them as inline code without Member Type when `text` not is provided, or as empty text if neither the text nor `crefAttribute` are valid.

Example
Input:
> /// \<param name="theme"\>The \<see cref="PaintTheme"/\> to be unregistered.</param>

Current output:
> The  to be unregistered.

Improved output:
> The `DV.Customization.Paint.PaintTheme` to be unregistered.